### PR TITLE
(cleanup) Updated preamble.js

### DIFF
--- a/_sources/docs/api_reference/preamble.js.txt
+++ b/_sources/docs/api_reference/preamble.js.txt
@@ -4,7 +4,7 @@ preamble.js (ready-for-review)
 
 The JavaScript APIs in `preamble.js <https://github.com/kripken/emscripten/blob/master/src/preamble.js>`_ provide programmatic access for interacting with the compiled C code, including: calling compiled C functions, accessing memory, converting pointers to JavaScript ``Strings`` and ``Strings`` to pointers (with different encodings/formats), and other convenience functions.
 
-.. note:: All functions should be called though the ``Module`` object (for example: ``Module.functionName``). At optimisation ``-O2`` (and higher) function names are minified by the closure compiler, and calling them directly will fail.
+.. note:: All functions should be called though the ``Module`` object (for example: ``Module.functionName``). At optimisation ``-O2`` (and higher) function names are minified by the closure compiler, and calling them directly will fail unless they are exposed with ``EXPORTED_FUNCTIONS``).
 
 
 .. contents:: Table of Contents
@@ -36,7 +36,7 @@ Calling compiled C functions from JavaScript
 	
 	.. note:: 
 		- ``ccall`` uses the C stack for temporary values. If you pass a string then it is only "alive" until the call is complete. If the code being called saves the pointer to be used later, it may point to invalid data. 
-		- If you need a string to live forever, you can create it, for example, using ``malloc`` and :js:func:`writeStringToMemory`. However, you must later delete it manually!	
+		- If you need a string to live forever, you can create it, for example, using ``_malloc`` and :js:func:`writeStringToMemory`. However, you must later delete it manually!	
 		- LLVM optimizations can inline and remove functions, after which you will not be able to call them. Similarly, function names minified by the *Closure Compiler* are inaccessible. In either case, the solution is to add the functions to the ``EXPORTED_FUNCTIONS`` list when you invoke *emcc* :  
 		
 			::
@@ -79,7 +79,7 @@ Calling compiled C functions from JavaScript
 	
 	.. note:: 
 		- ``cwrap`` uses the C stack for temporary values. If you pass a string then it is only "alive" until the call is complete. If the code being called saves the pointer to be used later, it may point to invalid data. 
-		- If you need a string to live forever, you can create it, for example, using ``malloc`` and :js:func:`writeStringToMemory`. However, you must later delete it manually!
+		- If you need a string to live forever, you can create it, for example, using ``_malloc`` and :js:func:`writeStringToMemory`. However, you must later delete it manually!
 		- LLVM optimizations can inline and remove functions, after which you will not be able to "wrap" them. Similarly, function names minified by the *Closure Compiler* are inaccessible. In either case, the solution is to add the functions to the ``EXPORTED_FUNCTIONS`` list when you invoke *emcc* :  
 		
 			::
@@ -109,7 +109,7 @@ Accessing memory
 	
 	.. note::
 		- :js:func:`setValue` and :js:func:`getValue` only do *aligned* writes and reads.
-		- The ``type`` is an LLVM IR type (one of ``i8``, ``i16``, ``i32``, ``i64``, ``float``, ``double``, or a pointer type like ``i8*`` or just *), not JavaScript types as used in :js:func:`ccall` or :js:func:`cwrap`. This is a lower-level operation, and we do need to care what specific type is being used.	
+		- The ``type`` is an LLVM IR type (one of ``i8``, ``i16``, ``i32``, ``i64``, ``float``, ``double``, or a pointer type like ``i8*`` or just ``*``), not JavaScript types as used in :js:func:`ccall` or :js:func:`cwrap`. This is a lower-level operation, and we do need to care what specific type is being used.	
 
 	:param ptr: A pointer (number) representing the memory address.  
 	:param value: The value to be stored 	
@@ -125,7 +125,7 @@ Accessing memory
 
 	.. note::
 		- :js:func:`setValue` and :js:func:`getValue` only do *aligned* writes and reads!
-		- The ``type` is an LLVM IR type (one of ``i8``,``i16``,``i32``,``i64``,``float``,``double`, or a pointer type like `i8*` or just *), not JavaScript types as used in :js:func:`ccall` or :js:func:`cwrap`. This is a lower-level operation, and we do need to care what specific type is being used.	
+		- The ``type`` is an LLVM IR type (one of ``i8``,``i16``,``i32``,``i64``,``float``,``double`, or a pointer type like `i8*` or just ``*``), not JavaScript types as used in :js:func:`ccall` or :js:func:`cwrap`. This is a lower-level operation, and we do need to care what specific type is being used.	
 
 	:param ptr: A pointer (number) representing the memory address.  
 	:param type: An LLVM IR type as a string (see "note" above). 	
@@ -313,9 +313,7 @@ Stack trace
 Type accessors for Typed Arrays Mode 2
 ==========================================
 
-When using :ref:`typed-arrays-mode-2` a type array buffer is used to represent memory, with different views into it giving access to the different types. The views for accessing different types of memory are listed below.
-
-.. COMMENT (not rendered): **HamishW** Link to TO TYPED ARRAYS MODE2 DOCUMENTATION when this is ported
+When using :ref:`typed-arrays-mode-2` (on by default)  a typed ``ArrayBuffer`` is used to represent memory, with different views into the same buffer giving access to the different types. The views for accessing different types of memory are listed below.
 
 
 .. js:data:: HEAP8


### PR DESCRIPTION
##### This commit makes the following changes:
- Note EXPORTED_FUNCTIONS when saying that mangled functions fail
- Reference malloc as _malloc, as this is how it is called form Module
- Fix formatting in setValue/getValue
- Change array buffer to ArrayBuffer
- Remove outdated note to link TYPED ARRAYS MODE2 DOCUMENTATION

---

I'm not sure if this is the right place to contribute to these docs. If it is not, could you point me to the right place? I couldn't find the `site/` mentioned by the `Readme`.

Also, I'd love to help out more in this project. Is it appropriate to be looking at the docs? Is there somewhere I can be of more use, having just been introduced to the project?
