### PR TITLE
fix wrong parameter name

### DIFF
--- a/_sources/docs/tools_reference/emcc.txt
+++ b/_sources/docs/tools_reference/emcc.txt
@@ -256,7 +256,7 @@ Options that are modified or new in *emcc* are listed below:
 
 	will by default generate an output name 'dir/a.o', but this cmdline param can be passed to generate a file with a custom suffix 'dir/a.ext'.  
        
-   * - ``--valid_abspath path``
+   * - ``--valid-abspath path``
      - Whitelist an absolute path to prevent warnings about absolute include paths.
 	 
 


### PR DESCRIPTION
Changed '--valid_abspath' to '--valid-abspath'.
